### PR TITLE
Update component to use latest upstream chart

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,7 +2,9 @@ parameters:
   metrics_server:
     namespace: syn-metrics-server
     charts:
-      metrics-server: '2.12.0'
+      metrics-server:
+        source: https://kubernetes-sigs.github.io/metrics-server
+        version: '3.8.2'
     images:
       metrics_server:
         image: k8s.gcr.io/metrics-server/metrics-server

--- a/class/metrics-server.yml
+++ b/class/metrics-server.yml
@@ -2,10 +2,10 @@ parameters:
   kapitan:
     dependencies:
       - type: helm
-        source: https://charts.appuio.ch
+        source: ${metrics_server:charts:metrics-server:source}
         chart_name: metrics-server
-        version: ${metrics_server:charts:metrics-server}
-        output_path: dependencies/metrics-server/helmcharts/metrics-server
+        version: ${metrics_server:charts:metrics-server:version}
+        output_path: dependencies/metrics-server/helmcharts/metrics-server/${metrics_server:charts:metrics-server:version}/
     compile:
       - input_paths:
           - metrics-server/component/app.jsonnet
@@ -18,7 +18,7 @@ parameters:
       - output_path: metrics-server/01_helmchart
         input_type: helm
         input_paths:
-          - metrics-server/helmcharts/metrics-server
+          - metrics-server/helmcharts/metrics-server/${metrics_server:charts:metrics-server:version}
         helm_values:
           image:
             repository: ${metrics_server:images:metrics_server:image}


### PR DESCRIPTION
Switch to the latest Helm chart provided by kubernetes-sigs/metrics-server. This should ensure that the component can be installed on recent K8s.
   
Additionally, we also update the component to adhere to the component best practices for handling Helm dependencies.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
